### PR TITLE
cargo to 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gcs-rsync"
 version = "0.1.7"
-edition = "2018"
+edition = "2021"
 description = "rsync support for gcs with higher perf than gsutil rsync"
 license = "MIT"
 repository = "https://github.com/cboudereau/gcs-rsync"


### PR DESCRIPTION
update to 2021
- ca fix --edition
- bump 2021 version in manifest
- ca fix