### PR TITLE
GCP metadata server credentials support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Cargo.lock
 flamegraph.svg
 .env
 .DS_Store
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ async-trait      = "0.1"
 percent-encoding = { version = "2",    default-features = false }
 bytes            = { version = "1.1",  default-features = false }
 base64           = { version = "0.13", default-features = false }
-tokio-util       = "0.6"
+tokio-util       = "0.7"
 crc32c           = "0.6"
 filetime         = "0.2"
 

--- a/Dockerfile.meta
+++ b/Dockerfile.meta
@@ -1,0 +1,11 @@
+FROM rust:alpine as builder
+RUN apk add --no-cache musl-dev pkgconfig openssl-dev
+COPY . /app 
+WORKDIR /app
+
+RUN cargo build --release --target=x86_64-unknown-linux-musl --example gcs-rsync-meta
+
+FROM alpine:latest
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/examples/gcs-rsync-meta /app/gcs-rsync-meta
+WORKDIR /app
+ENTRYPOINT [ "/app/gcs-rsync-meta" ]

--- a/examples/gcs-rsync-meta.rs
+++ b/examples/gcs-rsync-meta.rs
@@ -1,0 +1,90 @@
+use std::{path::Path, str::FromStr};
+
+use futures::{StreamExt, TryStreamExt};
+use gcs_rsync::{
+    storage::{credentials::metadata, Object},
+    sync::{GcsSource, RSync, RSyncError, RSyncResult},
+};
+
+use structopt::StructOpt;
+use gcs_rsync::oauth2::token::{GoogleMetadataServerCredentials};
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "gcs-rsync",
+    about = "synchronize fs or gcs source to destination"
+)]
+struct Opt {
+    /// Activate mirror mode (sync by default)
+    #[structopt(short, long)]
+    mirror: bool,
+
+    /// Restore mtime on filesystem (disabled by default)
+    #[structopt(short, long)]
+    restore_fs_mtime: bool,
+
+    /// Source path: can be either gs (gs://bucket/path/to/object) or fs source
+    #[structopt()]
+    source: String,
+
+    /// Destination path: can be either gs (gs://bucket/path/to/object) or fs source
+    #[structopt()]
+    dest: String,
+}
+
+async fn get_source(path: &str, is_dest: bool) -> RSyncResult<GcsSource<GoogleMetadataServerCredentials>> {
+    match Object::from_str(path).ok() {
+        Some(o) => {
+            let token_generator = metadata::init()
+                .await
+                .map_err(RSyncError::StorageError)?;
+            GcsSource::gcs(token_generator, o.bucket.as_str(), o.name.as_str()).await
+        }
+        None => {
+            let path = Path::new(path);
+            if path.exists() || is_dest {
+                Ok(GcsSource::fs(path))
+            } else {
+                Err(RSyncError::EmptyRelativePathError)
+            }
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> RSyncResult<()> {
+    let num_cpus = num_cpus::get();
+
+    let opt = Opt::from_args();
+
+    let source = get_source(&opt.source, false).await?;
+    let dest = get_source(&opt.dest, true).await?;
+
+    let rsync = RSync::new(source, dest).with_restore_fs_mtime(opt.restore_fs_mtime);
+
+    if opt.mirror {
+        println!("mirroring {} > {}", &opt.source, &opt.dest);
+        rsync
+            .mirror()
+            .await
+            .try_buffer_unordered(num_cpus)
+            .for_each(|x| {
+                println!("{:?}", x);
+                futures::future::ready(())
+            })
+            .await;
+    } else {
+        println!("syncing {} > {}", &opt.source, &opt.dest);
+        rsync
+            .sync()
+            .await
+            .try_buffer_unordered(num_cpus)
+            .for_each(|x| {
+                println!("{:?}", x);
+                futures::future::ready(())
+            })
+            .await;
+    };
+
+    Ok(())
+}

--- a/src/gcp/storage/mod.rs
+++ b/src/gcp/storage/mod.rs
@@ -69,6 +69,16 @@ pub mod credentials {
                 .map_err(super::super::Error::GcsTokenError)?)
         }
     }
+
+    pub mod metadata {
+        use crate::gcp::oauth2::token::GoogleMetadataServerCredentials;
+
+        pub async fn init() -> super::super::StorageResult<GoogleMetadataServerCredentials> {
+            Ok(GoogleMetadataServerCredentials::init()
+                   .await
+                .map_err(super::super::Error::GcsTokenError)?)
+        }
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Added credentials functions to acquire tokens from the GCP Metadata servers when running on GCP infrastructure.
This allows the application to utilise the VM's native service account or in case of GKE the Workload Identity service account, in doing so eliminating the need to embed credentials as files.