### PR TITLE
[Reworked] GCP metadata server credentials support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
   check:
     name: code coverage (unit + integration tests)
     env:
-      GOOGLE_APPLICATION_CREDENTIALS_TOKEN: ${{ secrets.TEST_USELESS_DATA_TOKEN }} 
+      GOOGLE_APPLICATION_CREDENTIALS_TOKEN: ${{ secrets.TEST_GOOGLE_APPLICATION_CREDENTIALS_TOKEN }} 
       TEST_SERVICE_ACCOUNT_TOKEN: ${{ secrets.TEST_SERVICE_ACCOUNT_TOKEN }} 
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ async-trait      = "0.1"
 percent-encoding = { version = "2",    default-features = false }
 bytes            = { version = "1.1",  default-features = false }
 base64           = { version = "0.13", default-features = false }
-tokio-util       = "0.6"
+tokio-util       = "0.7"
 crc32c           = "0.6"
 filetime         = "0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcs-rsync"
-version = "0.1.11"
+version = "0.2.0"
 edition = "2018"
 description = "rsync support for gcs with higher perf than gsutil rsync"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gcs-rsync"
 version = "0.2.0"
-edition = "2018"
+edition = "2021"
 description = "rsync support for gcs with higher perf than gsutil rsync"
 license = "MIT"
 repository = "https://github.com/cboudereau/gcs-rsync"

--- a/examples/bucket_to_bucket_sync.rs
+++ b/examples/bucket_to_bucket_sync.rs
@@ -6,7 +6,7 @@ use gcs_rsync::{
 
 #[tokio::main]
 async fn main() -> RSyncResult<()> {
-    let token_generator = authorizeduser::default().await.unwrap();
+    let token_generator = Box::new(authorizeduser::default().await.unwrap());
 
     let test_prefix = env!("EXAMPLE_PREFIX");
     let bucket = env!("EXAMPLE_BUCKET");
@@ -14,7 +14,6 @@ async fn main() -> RSyncResult<()> {
     let source = ReaderWriter::gcs(token_generator, bucket, test_prefix)
         .await
         .unwrap();
-    let token_generator = authorizeduser::default().await.unwrap();
 
     let dest_prefix = format!("{}_dest", test_prefix);
     let dest = ReaderWriter::gcs(token_generator, bucket, &dest_prefix)

--- a/examples/bucket_to_bucket_sync.rs
+++ b/examples/bucket_to_bucket_sync.rs
@@ -15,6 +15,7 @@ async fn main() -> RSyncResult<()> {
         .await
         .unwrap();
 
+    let token_generator = Box::new(authorizeduser::default().await.unwrap());
     let dest_prefix = format!("{}_dest", test_prefix);
     let dest = ReaderWriter::gcs(token_generator, bucket, &dest_prefix)
         .await

--- a/examples/bucket_to_folder_mirror.rs
+++ b/examples/bucket_to_folder_mirror.rs
@@ -8,7 +8,7 @@ use gcs_rsync::{
 
 #[tokio::main]
 async fn main() -> RSyncResult<()> {
-    let token_generator = authorizeduser::default().await.unwrap();
+    let token_generator = Box::new(authorizeduser::default().await.unwrap());
 
     let home_dir = env!("HOME");
     let test_prefix = env!("EXAMPLE_PREFIX");

--- a/examples/bucket_to_folder_sync.rs
+++ b/examples/bucket_to_folder_sync.rs
@@ -8,7 +8,7 @@ use gcs_rsync::{
 
 #[tokio::main]
 async fn main() -> RSyncResult<()> {
-    let token_generator = authorizeduser::default().await.unwrap();
+    let token_generator = Box::new(authorizeduser::default().await.unwrap());
 
     let home_dir = env!("HOME");
     let test_prefix = env!("EXAMPLE_PREFIX");

--- a/examples/delete_object.rs
+++ b/examples/delete_object.rs
@@ -7,7 +7,7 @@ async fn main() -> StorageResult<()> {
     let name = args[2].as_str();
     let object = Object::new(bucket, name)?;
 
-    let auc = credentials::authorizeduser::default().await?;
+    let auc = Box::new(credentials::authorizeduser::default().await?);
     let object_client = ObjectClient::new(auc).await?;
 
     object_client.delete(&object).await?;

--- a/examples/download_object.rs
+++ b/examples/download_object.rs
@@ -14,7 +14,7 @@ async fn main() -> StorageResult<()> {
     let name = args[2].as_str();
     let output_path = args[3].to_owned();
 
-    let auc = credentials::authorizeduser::default().await?;
+    let auc = Box::new(credentials::authorizeduser::default().await?);
     let object_client = ObjectClient::new(auc).await?;
 
     let file_name = Path::new(&name).file_name().unwrap().to_string_lossy();

--- a/examples/gcs-rsync.rs
+++ b/examples/gcs-rsync.rs
@@ -2,8 +2,8 @@ use std::{path::Path, str::FromStr};
 
 use futures::{StreamExt, TryStreamExt};
 use gcs_rsync::{
-    storage::{credentials::authorizeduser, Object},
-    sync::{DefaultSource, RSync, RSyncError, RSyncResult},
+    storage::{credentials::{authorizeduser, metadata}, Object},
+    sync::{Source, RSync, RSyncError, RSyncResult}, oauth2::token::TokenGenerator,
 };
 
 use structopt::StructOpt;
@@ -14,6 +14,10 @@ use structopt::StructOpt;
     about = "synchronize fs or gcs source to destination"
 )]
 struct Opt {
+    /// Use Google metadata api for authentication
+    #[structopt(short, long)]
+    use_metadata_token_api: bool,
+
     /// Activate mirror mode (sync by default)
     #[structopt(short, long)]
     mirror: bool,
@@ -31,18 +35,24 @@ struct Opt {
     dest: String,
 }
 
-async fn get_source(path: &str, is_dest: bool) -> RSyncResult<DefaultSource> {
+async fn get_source(path: &str, is_dest: bool, use_metadata_token_api: bool) -> RSyncResult<Source> {
     match Object::from_str(path).ok() {
         Some(o) => {
-            let token_generator = authorizeduser::default()
-                .await
-                .map_err(RSyncError::StorageError)?;
-            DefaultSource::gcs(token_generator, o.bucket.as_str(), o.name.as_str()).await
+            let token_generator: Box<dyn TokenGenerator> = 
+                if use_metadata_token_api {
+                    Box::new(metadata::default()
+                    .map_err(RSyncError::StorageError)?)
+                } else {
+                    Box::new(authorizeduser::default()
+                    .await
+                    .map_err(RSyncError::StorageError)?)
+                };
+            Source::gcs(token_generator, o.bucket.as_str(), o.name.as_str()).await
         }
         None => {
             let path = Path::new(path);
             if path.exists() || is_dest {
-                Ok(DefaultSource::fs(path))
+                Ok(Source::fs(path))
             } else {
                 Err(RSyncError::EmptyRelativePathError)
             }
@@ -56,8 +66,8 @@ async fn main() -> RSyncResult<()> {
 
     let opt = Opt::from_args();
 
-    let source = get_source(&opt.source, false).await?;
-    let dest = get_source(&opt.dest, true).await?;
+    let source = get_source(&opt.source, false, opt.use_metadata_token_api).await?;
+    let dest = get_source(&opt.dest, true, opt.use_metadata_token_api).await?;
 
     let rsync = RSync::new(source, dest).with_restore_fs_mtime(opt.restore_fs_mtime);
 

--- a/examples/list_objects.rs
+++ b/examples/list_objects.rs
@@ -7,7 +7,7 @@ async fn main() -> StorageResult<()> {
     let bucket = args[1].as_str();
     let prefix = args[2].to_owned();
 
-    let auc = credentials::authorizeduser::default().await?;
+    let auc = Box::new(credentials::authorizeduser::default().await?);
     let object_client = ObjectClient::new(auc).await?;
 
     let objects_list_request = ObjectsListRequest {

--- a/examples/list_objects_service_account.rs
+++ b/examples/list_objects_service_account.rs
@@ -7,10 +7,10 @@ async fn main() -> StorageResult<()> {
     let bucket = args[1].as_str();
     let prefix = args[2].to_owned();
 
-    let auc = credentials::serviceaccount::default(
+    let auc = Box::new(credentials::serviceaccount::default(
         "https://www.googleapis.com/auth/devstorage.full_control",
     )
-    .await?;
+    .await?);
     let object_client = ObjectClient::new(auc).await?;
 
     let objects_list_request = ObjectsListRequest {

--- a/examples/list_objects_service_account.rs
+++ b/examples/list_objects_service_account.rs
@@ -7,10 +7,12 @@ async fn main() -> StorageResult<()> {
     let bucket = args[1].as_str();
     let prefix = args[2].to_owned();
 
-    let auc = Box::new(credentials::serviceaccount::default(
-        "https://www.googleapis.com/auth/devstorage.full_control",
-    )
-    .await?);
+    let auc = Box::new(
+        credentials::serviceaccount::default(
+            "https://www.googleapis.com/auth/devstorage.full_control",
+        )
+        .await?,
+    );
     let object_client = ObjectClient::new(auc).await?;
 
     let objects_list_request = ObjectsListRequest {

--- a/examples/upload_object.rs
+++ b/examples/upload_object.rs
@@ -10,7 +10,7 @@ async fn main() -> StorageResult<()> {
     let prefix = args[2].to_owned();
     let file_path = args[3].to_owned();
 
-    let auc = credentials::authorizeduser::default().await?;
+    let auc = Box::new(credentials::authorizeduser::default().await?);
     let object_client = ObjectClient::new(auc).await?;
 
     let file_path = Path::new(&file_path);

--- a/src/gcp/oauth2/token.rs
+++ b/src/gcp/oauth2/token.rs
@@ -64,7 +64,7 @@ pub trait TokenGenerator {
 }
 
 impl Debug for dyn TokenGenerator {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Ok(())
     }
 }
@@ -136,7 +136,7 @@ impl TokenGenerator for ServiceAccountCredentials {
 #[async_trait::async_trait]
 impl TokenGenerator for GoogleMetadataServerCredentials {
     async fn get(&self, client: &Client) -> TokenResult<Token> {
-        const DEFAULT_TOKEN_GCP_URI: &'static str = "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
+        const DEFAULT_TOKEN_GCP_URI: &str = "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
 
         let token: DeserializedResponse<Token> = client
             .client
@@ -192,7 +192,7 @@ struct Claims<'a> {
     scope: &'a str,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct AuthorizedUserCredentials {
     client_id: String,
     client_secret: String,
@@ -222,7 +222,7 @@ impl AuthorizedUserCredentials {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct ServiceAccountCredentials {
     r#type: String,
     project_id: String,
@@ -260,7 +260,7 @@ impl ServiceAccountCredentials {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct GoogleMetadataServerCredentials {}
 
 impl GoogleMetadataServerCredentials {

--- a/src/gcp/oauth2/token.rs
+++ b/src/gcp/oauth2/token.rs
@@ -141,7 +141,7 @@ impl TokenGenerator for GoogleMetadataServerCredentials {
         let token: DeserializedResponse<Token> = client
             .client
             .get(DEFAULT_TOKEN_GCP_URI)
-            .header("Metadata-Flavor","Google")
+            .header("Metadata-Flavor", "Google")
             .send()
             .await
             .map_err(Error::HttpError)?
@@ -261,13 +261,11 @@ impl ServiceAccountCredentials {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct GoogleMetadataServerCredentials {
-}
+pub struct GoogleMetadataServerCredentials {}
 
 impl GoogleMetadataServerCredentials {
-
     pub fn default() -> TokenResult<Self> {
-        Ok(GoogleMetadataServerCredentials{})
+        Ok(GoogleMetadataServerCredentials {})
     }
 }
 

--- a/src/gcp/storage/client.rs
+++ b/src/gcp/storage/client.rs
@@ -12,9 +12,9 @@ use serde::{de::DeserializeOwned, Serialize};
 use tokio::sync::RwLock;
 
 #[derive(Debug)]
-pub(super) struct StorageClient<T> {
+pub(super) struct StorageClient {
     client: Client,
-    token_generator: T,
+    token_generator: Box<dyn TokenGenerator>,
     token: RwLock<Token>,
 }
 
@@ -23,8 +23,8 @@ const MT_END_SEPARATOR: &[u8] = b"\n--gcs-storage--";
 const MT_CONTENT_TYPE: &[u8] = b"Content-Type: application/octet-stream";
 const MT_METADATA_TYPE: &[u8] = b"Content-Type: application/json; charset=utf-8\n\n";
 
-impl<T: TokenGenerator> StorageClient<T> {
-    pub async fn new(token_generator: T) -> StorageResult<Self> {
+impl StorageClient {
+    pub async fn new(token_generator: Box<dyn TokenGenerator>) -> StorageResult<Self> {
         let client = Client::default();
         let token = token_generator
             .get(&client)

--- a/src/gcp/storage/mod.rs
+++ b/src/gcp/storage/mod.rs
@@ -44,6 +44,7 @@ pub mod credentials {
                 .map_err(super::super::Error::GcsTokenError)
         }
     }
+
     pub mod authorizeduser {
 
         use crate::gcp::oauth2::token::AuthorizedUserCredentials;
@@ -67,6 +68,15 @@ pub mod credentials {
             Ok(AuthorizedUserCredentials::from_file(file_path)
                 .await
                 .map_err(super::super::Error::GcsTokenError)?)
+        }
+    }
+
+    pub mod metadata {
+
+        use crate::oauth2::token::GoogleMetadataServerCredentials;
+
+        pub fn default() -> super::super::StorageResult<GoogleMetadataServerCredentials> {
+            GoogleMetadataServerCredentials::default().map_err(super::super::Error::GcsTokenError)
         }
     }
 }

--- a/src/gcp/storage/mod.rs
+++ b/src/gcp/storage/mod.rs
@@ -50,9 +50,9 @@ pub mod credentials {
         use crate::gcp::oauth2::token::AuthorizedUserCredentials;
 
         pub async fn default() -> super::super::StorageResult<AuthorizedUserCredentials> {
-            Ok(AuthorizedUserCredentials::default()
+            AuthorizedUserCredentials::default()
                 .await
-                .map_err(super::super::Error::GcsTokenError)?)
+                .map_err(super::super::Error::GcsTokenError)
         }
 
         pub fn from_str(str: &str) -> super::super::StorageResult<AuthorizedUserCredentials> {
@@ -65,9 +65,9 @@ pub mod credentials {
         where
             T: AsRef<std::path::Path>,
         {
-            Ok(AuthorizedUserCredentials::from_file(file_path)
+            AuthorizedUserCredentials::from_file(file_path)
                 .await
-                .map_err(super::super::Error::GcsTokenError)?)
+                .map_err(super::super::Error::GcsTokenError)
         }
     }
 

--- a/src/gcp/storage/object.rs
+++ b/src/gcp/storage/object.rs
@@ -37,8 +37,7 @@ impl ObjectClient {
         o: &Object,
     ) -> StorageResult<impl Stream<Item = StorageResult<bytes::Bytes>>> {
         let url = o.url();
-        self
-            .storage_client
+        self.storage_client
             .get_as_stream(&url, &[("alt", "media")])
             .await
     }

--- a/src/gcp/storage/object.rs
+++ b/src/gcp/storage/object.rs
@@ -37,10 +37,10 @@ impl ObjectClient {
         o: &Object,
     ) -> StorageResult<impl Stream<Item = StorageResult<bytes::Bytes>>> {
         let url = o.url();
-        Ok(self
+        self
             .storage_client
             .get_as_stream(&url, &[("alt", "media")])
-            .await?)
+            .await
     }
 
     pub async fn upload<S>(&self, o: &Object, stream: S) -> StorageResult<()>

--- a/src/gcp/storage/object.rs
+++ b/src/gcp/storage/object.rs
@@ -8,22 +8,17 @@ use super::{
     Bucket, StorageResult, {Object, ObjectsListRequest, PartialObject},
 };
 
-pub struct ObjectClient<T> {
-    storage_client: StorageClient<T>,
+pub struct ObjectClient {
+    storage_client: StorageClient,
 }
 
-impl<T: TokenGenerator> ObjectClient<T> {
-    pub async fn new(token_generator: T) -> StorageResult<Self> {
+impl ObjectClient {
+    pub async fn new(token_generator: Box<dyn TokenGenerator>) -> StorageResult<Self> {
         Ok(Self {
             storage_client: StorageClient::new(token_generator).await?,
         })
     }
-}
 
-impl<T> ObjectClient<T>
-where
-    T: TokenGenerator,
-{
     pub async fn get(&self, o: &Object, fields: &str) -> StorageResult<PartialObject> {
         let url = o.url();
         self.storage_client

--- a/src/gcp/storage/resources/object.rs
+++ b/src/gcp/storage/resources/object.rs
@@ -2,7 +2,7 @@ use std::{convert::TryInto, fmt::Display, str::FromStr};
 
 use crate::storage::{Error, StorageResult};
 
-#[derive(Debug, PartialEq, serde::Serialize, Clone)]
+#[derive(Debug, PartialEq, Eq, serde::Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum Projection {
     Full,
@@ -10,7 +10,7 @@ pub enum Projection {
 }
 
 /// See [GCS list API reference](https://cloud.google.com/storage/docs/json_api/v1/objects/list)
-#[derive(Debug, PartialEq, serde::Serialize, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, serde::Serialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ObjectsListRequest {
     /// [Partial Response](https://cloud.google.com/storage/docs/json_api#partial-response)
@@ -26,12 +26,12 @@ pub struct ObjectsListRequest {
     pub versions: Option<bool>,
 }
 
-#[derive(Debug, PartialEq, serde::Serialize, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, serde::Serialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ObjectMetadata {
     pub metadata: Metadata,
 }
-#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Metadata {
     #[serde(
@@ -56,7 +56,7 @@ pub struct Objects {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Object {
     pub bucket: String,
@@ -94,7 +94,7 @@ fn percent_encode(input: &str) -> String {
 
 impl Object {
     pub fn gs_url(&self) -> GsUrl {
-        return format!("gs://{}/{}", &self.bucket, &self.name);
+        format!("gs://{}/{}", &self.bucket, &self.name)
     }
 
     /// References: `<https://cloud.google.com/storage/docs/naming-objects>`
@@ -133,7 +133,7 @@ impl Object {
     }
 }
 
-#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Bucket {
     name: String,
@@ -168,7 +168,7 @@ impl TryInto<Object> for PartialObject {
     }
 }
 
-#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, Default)]
+#[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PartialObject {
     pub bucket: Option<String>,
@@ -194,7 +194,7 @@ pub struct PartialObject {
     pub etag: Option<String>,
 }
 
-#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, Default)]
+#[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct CRC32C {
     value: u32,
@@ -208,7 +208,7 @@ impl CRC32C {
         self.value
     }
 }
-#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Base64EncodedCRC32CError {
     Base64DecodeError(String),
     Base64ToU32BigEndianError(Vec<u8>),

--- a/src/gcp/sync/fs.rs
+++ b/src/gcp/sync/fs.rs
@@ -172,7 +172,7 @@ impl FsClient {
             .try_fold(
                 BufWriter::with_capacity(crate::DEFAULT_BUF_SIZE, file),
                 |mut buf_writer, data| async move {
-                    let _ = buf_writer.write_all(&data).await.map_err(|e| {
+                    buf_writer.write_all(&data).await.map_err(|e| {
                         RSyncError::fs_io_error("buffered write to file failed", file_path, e)
                     })?;
                     Ok(buf_writer)

--- a/src/gcp/sync/gcs.rs
+++ b/src/gcp/sync/gcs.rs
@@ -75,9 +75,12 @@ impl ObjectPrefix {
 
 type Size = u64;
 
-impl GcsClient
-{
-    pub(super) async fn new(token_generator: Box<dyn TokenGenerator>, bucket: &str, prefix: &str) -> RSyncResult<Self> {
+impl GcsClient {
+    pub(super) async fn new(
+        token_generator: Box<dyn TokenGenerator>,
+        bucket: &str,
+        prefix: &str,
+    ) -> RSyncResult<Self> {
         let object_client = ObjectClient::new(token_generator)
             .await
             .map_err(RSyncError::StorageError)?;

--- a/src/gcp/sync/gcs.rs
+++ b/src/gcp/sync/gcs.rs
@@ -10,8 +10,8 @@ use crate::{
     storage::{Object, ObjectClient, ObjectsListRequest, PartialObject},
 };
 
-pub(super) struct GcsClient<T> {
-    client: ObjectClient<T>,
+pub(super) struct GcsClient {
+    client: ObjectClient,
     object_prefix: ObjectPrefix,
 }
 
@@ -75,11 +75,9 @@ impl ObjectPrefix {
 
 type Size = u64;
 
-impl<T> GcsClient<T>
-where
-    T: TokenGenerator,
+impl GcsClient
 {
-    pub(super) async fn new(token_generator: T, bucket: &str, prefix: &str) -> RSyncResult<Self> {
+    pub(super) async fn new(token_generator: Box<dyn TokenGenerator>, bucket: &str, prefix: &str) -> RSyncResult<Self> {
         let object_client = ObjectClient::new(token_generator)
             .await
             .map_err(RSyncError::StorageError)?;

--- a/src/gcp/sync/mod.rs
+++ b/src/gcp/sync/mod.rs
@@ -19,13 +19,16 @@ pub struct ReaderWriter {
 
 pub type Source = ReaderWriter;
 
-impl ReaderWriter
-{
+impl ReaderWriter {
     fn new(inner: ReaderWriterInternal) -> Self {
         Self { inner }
     }
 
-    pub async fn gcs(token_generator: Box<dyn TokenGenerator>, bucket: &str, prefix: &str) -> RSyncResult<Self> {
+    pub async fn gcs(
+        token_generator: Box<dyn TokenGenerator>,
+        bucket: &str,
+        prefix: &str,
+    ) -> RSyncResult<Self> {
         let client = GcsClient::new(token_generator, bucket, prefix).await?;
         Ok(Self::new(ReaderWriterInternal::Gcs(client)))
     }
@@ -44,8 +47,7 @@ enum ReaderWriterInternal {
 
 type Size = u64;
 
-impl ReaderWriterInternal
-{
+impl ReaderWriterInternal {
     async fn list(
         &self,
     ) -> Either<
@@ -132,8 +134,7 @@ pub struct RSync {
     restore_fs_mtime: bool,
 }
 
-impl RSync
-{
+impl RSync {
     pub fn new(source: ReaderWriter, dest: ReaderWriter) -> Self {
         Self {
             source: source.inner,

--- a/tests/objects_integration_test.rs
+++ b/tests/objects_integration_test.rs
@@ -29,10 +29,7 @@ async fn test_test_config() {
     assert!(t.bucket().is_empty().not(), "bucket should not be empty");
 }
 
-async fn assert_delete_err(
-    object_client: &ObjectClient,
-    object: &Object,
-) {
+async fn assert_delete_err(object_client: &ObjectClient, object: &Object) {
     let delete_result = object_client.delete(object).await;
     assert!(
         delete_result.is_err(),
@@ -42,10 +39,7 @@ async fn assert_delete_err(
     );
 }
 
-async fn assert_delete_ok(
-    object_client: &ObjectClient,
-    object: &Object,
-) {
+async fn assert_delete_ok(object_client: &ObjectClient, object: &Object) {
     let delete_result = object_client.delete(object).await;
     assert!(
         delete_result.is_ok(),
@@ -65,11 +59,7 @@ async fn upload_bytes(
     object_client.upload(object, stream).await
 }
 
-async fn assert_upload_bytes(
-    object_client: &ObjectClient,
-    object: &Object,
-    content: &str,
-) {
+async fn assert_upload_bytes(object_client: &ObjectClient, object: &Object, content: &str) {
     let upload_result = upload_bytes(object_client, object, content).await;
     assert!(
         upload_result.is_ok(),
@@ -79,11 +69,7 @@ async fn assert_upload_bytes(
     );
 }
 
-async fn assert_download_bytes(
-    object_client: &ObjectClient,
-    object: &Object,
-    expected: &str,
-) {
+async fn assert_download_bytes(object_client: &ObjectClient, object: &Object, expected: &str) {
     let bytes = futures::stream::once(object_client.download(object))
         .try_flatten()
         .try_fold(Vec::new(), |mut bytes, buffer| {
@@ -102,7 +88,9 @@ async fn assert_download_bytes(
 async fn test_upload_multipart() {
     let test_config = GcsTestConfig::from_env().await;
     let object = test_config.object("with/path/object_mutlipart.txt");
-    let object_client = ObjectClient::new(Box::new(test_config.token())).await.unwrap();
+    let object_client = ObjectClient::new(Box::new(test_config.token()))
+        .await
+        .unwrap();
 
     let content = b"test multipart";
 
@@ -131,7 +119,9 @@ async fn test_upload_multipart() {
 async fn test_delete_upload_download_delete() {
     let test_config = GcsTestConfig::from_env().await;
     let object = test_config.object("object.txt");
-    let object_client = ObjectClient::new(Box::new(test_config.token())).await.unwrap();
+    let object_client = ObjectClient::new(Box::new(test_config.token()))
+        .await
+        .unwrap();
 
     let content = "hello";
     assert_delete_err(&object_client, &object).await;
@@ -144,7 +134,9 @@ async fn test_delete_upload_download_delete() {
 async fn test_get_object_ok() {
     let test_config = GcsTestConfig::from_env().await;
     let object = test_config.object("object.txt");
-    let object_client = ObjectClient::new(Box::new(test_config.token())).await.unwrap();
+    let object_client = ObjectClient::new(Box::new(test_config.token()))
+        .await
+        .unwrap();
 
     let content = "hello";
     assert_delete_err(&object_client, &object).await;
@@ -162,7 +154,9 @@ async fn test_get_object_ok() {
 async fn test_get_object_size() {
     let test_config = GcsTestConfig::from_env().await;
     let object = test_config.object("object.txt");
-    let object_client = ObjectClient::new(Box::new(test_config.token())).await.unwrap();
+    let object_client = ObjectClient::new(Box::new(test_config.token()))
+        .await
+        .unwrap();
 
     let content = "hello";
     assert_delete_err(&object_client, &object).await;
@@ -178,7 +172,9 @@ async fn test_get_object_size() {
 async fn test_get_object_not_found() {
     let test_config = GcsTestConfig::from_env().await;
     let object = test_config.object("object.txt");
-    let object_client = ObjectClient::new(Box::new(test_config.token())).await.unwrap();
+    let object_client = ObjectClient::new(Box::new(test_config.token()))
+        .await
+        .unwrap();
 
     let err = object_client
         .get(&object, "name,selfLink")
@@ -191,7 +187,9 @@ async fn test_get_object_not_found() {
 #[tokio::test]
 async fn test_upload_with_detailed_error() {
     let test_config = GcsTestConfig::from_env().await;
-    let object_client = ObjectClient::new(Box::new(test_config.token())).await.unwrap();
+    let object_client = ObjectClient::new(Box::new(test_config.token()))
+        .await
+        .unwrap();
     let object = Object::new("the_bad_bucket", "name").unwrap();
 
     let err = upload_bytes(&object_client, &object, "").await.unwrap_err();
@@ -210,7 +208,9 @@ async fn test_api_list_objects() {
         .map(|i| test_config.object(format!("object_{}", i).as_str()))
         .collect::<Vec<_>>();
 
-    let object_client = ObjectClient::new(Box::new(test_config.token())).await.unwrap();
+    let object_client = ObjectClient::new(Box::new(test_config.token()))
+        .await
+        .unwrap();
     futures::stream::iter(test_objects.iter())
         .for_each_concurrent(config::default::CONCURRENCY_LEVEL, |object| {
             assert_upload_bytes(&object_client, object, "hello")
@@ -247,7 +247,9 @@ async fn test_crc32c_object() {
     let bucket = test_config.bucket();
     let prefix = test_config.list_prefix();
     let test_object = &test_config.object("test_crc32c");
-    let object_client = ObjectClient::new(Box::new(test_config.token())).await.unwrap();
+    let object_client = ObjectClient::new(Box::new(test_config.token()))
+        .await
+        .unwrap();
     assert_upload_bytes(&object_client, test_object, "hello world!").await;
 
     let objects_list_request = ObjectsListRequest {

--- a/tests/objects_integration_test.rs
+++ b/tests/objects_integration_test.rs
@@ -2,7 +2,6 @@ use std::ops::Not;
 
 use futures::{StreamExt, TryStreamExt};
 use gcs_rsync::{
-    oauth2::token::AuthorizedUserCredentials,
     storage::{
         credentials, Metadata, Object, ObjectClient, ObjectMetadata, ObjectsListRequest,
         PartialObject, StorageResult,

--- a/tests/objects_integration_test.rs
+++ b/tests/objects_integration_test.rs
@@ -1,11 +1,9 @@
 use std::ops::Not;
 
 use futures::{StreamExt, TryStreamExt};
-use gcs_rsync::{
-    storage::{
-        credentials, Metadata, Object, ObjectClient, ObjectMetadata, ObjectsListRequest,
-        PartialObject, StorageResult,
-    },
+use gcs_rsync::storage::{
+    credentials, Metadata, Object, ObjectClient, ObjectMetadata, ObjectsListRequest, PartialObject,
+    StorageResult,
 };
 
 mod config;

--- a/tests/sync_mirror_integration_tests.rs
+++ b/tests/sync_mirror_integration_tests.rs
@@ -2,7 +2,6 @@ use std::path::{Path, PathBuf};
 
 use futures::{StreamExt, TryStreamExt};
 use gcs_rsync::{
-    oauth2::token::AuthorizedUserCredentials,
     storage::{
         credentials::{self, authorizeduser},
         Object, ObjectClient, StorageResult,

--- a/tests/sync_mirror_integration_tests.rs
+++ b/tests/sync_mirror_integration_tests.rs
@@ -7,9 +7,7 @@ use gcs_rsync::{
         credentials::{self, authorizeduser},
         Object, ObjectClient, StorageResult,
     },
-    sync::{
-        Source, RMirrorStatus, RSync, RSyncStatus, ReaderWriter, RelativePath,
-    },
+    sync::{RMirrorStatus, RSync, RSyncStatus, ReaderWriter, RelativePath, Source},
 };
 use tokio::io::AsyncWriteExt;
 
@@ -146,10 +144,7 @@ async fn test_fs_to_gcs_sync_and_mirror() {
 
 #[tokio::test]
 async fn test_sync_and_mirror_crc32c() {
-    async fn assert_delete_ok(
-        object_client: &ObjectClient,
-        object: &Object,
-    ) {
+    async fn assert_delete_ok(object_client: &ObjectClient, object: &Object) {
         let delete_result = object_client.delete(object).await;
         assert!(
             delete_result.is_ok(),
@@ -169,11 +164,7 @@ async fn test_sync_and_mirror_crc32c() {
         object_client.upload(object, stream).await
     }
 
-    async fn assert_upload_bytes(
-        object_client: &ObjectClient,
-        object: &Object,
-        content: &str,
-    ) {
+    async fn assert_upload_bytes(object_client: &ObjectClient, object: &Object, content: &str) {
         let upload_result = upload_bytes(object_client, object, content).await;
         assert!(
             upload_result.is_ok(),

--- a/tests/sync_mirror_integration_tests.rs
+++ b/tests/sync_mirror_integration_tests.rs
@@ -230,15 +230,13 @@ async fn test_fs_to_gcs_sync_and_mirror_base(set_fs_mtime: bool) {
         let bucket = test_config.bucket();
         let prefix = test_config.prefix();
 
-        let gcs_dest = Source::gcs(
+        Source::gcs(
             Box::new(test_config.token()),
             bucket.as_str(),
             prefix.to_str().unwrap(),
         )
         .await
-        .unwrap();
-
-        gcs_dest
+        .unwrap()
     }
     let gcs_dst_t = GcsTestConfig::from_env().await;
 


### PR DESCRIPTION
This is a picked version of #16 of @bryancymo to support google metadata token api integrated into one gcs-rsync example bin.

This version uses a dyn trait over TokenGenerator to avoid static dispatch issue when it comes to use the api.

In the end, only one gcs-rsync bin will be available and the feature can be activated by adding a flag : -u, --use-metadata-token-api

⚠️ This version breaks the compatibility over the TokenGenerator dyn trait

- [x] Use TokenGenerator dyn trait to switch between AuthorizedUser/Metadata in gcs-rsync example
- [x] Fix new clippy errors
- [x] Upgrade to Rust 2021
- [x] Provide a new conf to make integration tests working 