### PR TITLE
fix: code coverage tarpaulin issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: '0.15.0'
-          args: '-- --test-threads 1'
+          args: '--exclude-files src/lib.rs -- --test-threads 1'
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1.0.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: '0.15.0'
-          args: '--exclude-files src/lib.rs -- --test-threads 1'
+          args: '-- --test-threads 1'
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1.0.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,10 +62,10 @@ jobs:
           override: true
 
       - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.2
+        uses: actions-rs/tarpaulin@v0.1
         with:
           version: '0.15.0'
-          args: '-- --test-threads 1'
+          args: '--exclude-files src/lib.rs -- --test-threads 1'
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1.0.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
           override: true
 
       - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
+        uses: actions-rs/tarpaulin@v0.2
         with:
           version: '0.15.0'
           args: '-- --test-threads 1'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcs-rsync"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "rsync support for gcs with higher perf than gsutil rsync"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Cargo.toml
 
 ```bash
 [dependencies]
-gcs-rsync = "0.1"
+gcs-rsync = "0.2"
 ```
 
 ## How to install as cli tool

--- a/src/gcp/sync/mod.rs
+++ b/src/gcp/sync/mod.rs
@@ -216,7 +216,7 @@ impl RSync {
     ///
     /// #[tokio::main]
     /// async fn main() -> RSyncResult<()> {
-    ///     let token_generator = authorizeduser::default().await.unwrap();
+    ///     let token_generator = Box::new(authorizeduser::default().await.unwrap());
     ///
     ///     let home_dir = ".";
     ///     let test_prefix = "bucket_prefix_to_sync";
@@ -288,7 +288,7 @@ impl RSync {
     ///
     /// #[tokio::main]
     /// async fn main() -> RSyncResult<()> {
-    ///     let token_generator = authorizeduser::default().await.unwrap();
+    ///     let token_generator = Box::new(authorizeduser::default().await.unwrap());
     ///
     ///     let home_dir = ".";
     ///     let test_prefix = "bucket_prefix_to_sync";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> RSyncResult<()> {
-//!     let token_generator = authorizeduser::default().await.unwrap();
+//!     let token_generator = Box::new(authorizeduser::default().await.unwrap());
 //!
 //!     let home_dir = ".";
 //!     let test_prefix = "bucket_prefix_to_sync";


### PR DESCRIPTION
Fix code coverage since tarpaulin has a bug arround rust doc src/lib.rs.

The file src/lib.rs contains 64 lines but tarpaulin indicates 2.5K.