### PR TITLE
Sync + Send on TokenGenerator, scope for metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ base64           = { version = "0.13", default-features = false }
 tokio-util       = "0.7"
 crc32c           = "0.6"
 filetime         = "0.2"
+urlencoding      = "2.1"
 
 [dev-dependencies]
 tokio        = { version = "1.12", default-features = false, features = ["full"] }

--- a/src/gcp/oauth2/token.rs
+++ b/src/gcp/oauth2/token.rs
@@ -8,6 +8,7 @@ use std::{
     fmt::{Debug, Display},
     path::Path,
 };
+use urlencoding::encode;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct Token {
@@ -59,7 +60,7 @@ impl Token {
 }
 
 #[async_trait::async_trait]
-pub trait TokenGenerator {
+pub trait TokenGenerator: Sync + Send {
     async fn get(&self, client: &Client) -> TokenResult<Token>;
 }
 
@@ -136,11 +137,16 @@ impl TokenGenerator for ServiceAccountCredentials {
 #[async_trait::async_trait]
 impl TokenGenerator for GoogleMetadataServerCredentials {
     async fn get(&self, client: &Client) -> TokenResult<Token> {
+
         const DEFAULT_TOKEN_GCP_URI: &str = "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
+        let uri = match self.scope {
+            None => DEFAULT_TOKEN_GCP_URI.to_string(),
+            Some(ref scope) => format!("{}?{}", DEFAULT_TOKEN_GCP_URI, encode(format!("scopes={}", scope).as_str()))
+        };
 
         let token: DeserializedResponse<Token> = client
             .client
-            .get(DEFAULT_TOKEN_GCP_URI)
+            .get(uri)
             .header("Metadata-Flavor", "Google")
             .send()
             .await
@@ -261,11 +267,17 @@ impl ServiceAccountCredentials {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
-pub struct GoogleMetadataServerCredentials {}
+pub struct GoogleMetadataServerCredentials {
+    scope: Option<String>,
+}
 
 impl GoogleMetadataServerCredentials {
     pub fn default() -> TokenResult<Self> {
-        Ok(GoogleMetadataServerCredentials {})
+        Ok(GoogleMetadataServerCredentials { scope: None })
+    }
+    pub fn with_scope(mut self, scope: &str) -> Self {
+        self.scope = Some(scope.to_owned());
+        self
     }
 }
 

--- a/src/gcp/storage/mod.rs
+++ b/src/gcp/storage/mod.rs
@@ -78,6 +78,11 @@ pub mod credentials {
         pub fn default() -> super::super::StorageResult<GoogleMetadataServerCredentials> {
             GoogleMetadataServerCredentials::default().map_err(super::super::Error::GcsTokenError)
         }
+        pub fn with_scope(scope: &str) -> super::super::StorageResult<GoogleMetadataServerCredentials> {
+            GoogleMetadataServerCredentials::default()
+                .map(|x| x.with_scope(scope))
+                .map_err(super::super::Error::GcsTokenError)
+        }
     }
 }
 


### PR DESCRIPTION
Explicitly set Sync and Send on TokenGenerator so that it can be used in tokio tasks. 
Pass scope in GoogleMetadataCredentials and expose it in metadata factory.