### PR TITLE
fix: remove github action warnings when publishing crate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,9 +4,6 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-  pull_request:
-    branches: 
-      - '*'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,6 @@ jobs:
       with:
           toolchain: stable
           override: true
-    - uses: katyo/publish-crates@v1
+    - uses: katyo/publish-crates@v2
       with:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  pull_request:
+    branches: 
+      - '*'
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcs-rsync"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "rsync support for gcs with higher perf than gsutil rsync"
 license = "MIT"


### PR DESCRIPTION
fixes #26 