### PR TITLE
feat/prefix: add prefix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ docker run --rm -it -v ${GOOGLE_APPLICATION_CREDENTIALS}:/creds.json:ro -v <Your
 docker run --rm -it -v ${GOOGLE_APPLICATION_CREDENTIALS}:/creds.json:ro -v <YourFolderToDownloadTo>:/dest superbeeeeeee/gcs-rsync -r -m gs://<YourBucket>/<YourFolderToUpload>/ /dest
 ```
 
+### Mirror partial gcs with prefix to folder
+
+```bash
+docker run --rm -it -v ${GOOGLE_APPLICATION_CREDENTIALS}:/creds.json:ro -v <YourFolderToDownloadTo>:/dest superbeeeeeee/gcs-rsync -r -m gs://<YourBucket>/<YourFolderToUpload>/<YourPrefix> /dest
+```
+
 ### Include or Exclude files using glob pattern
 
 #### CLI gcs-rsync

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ cargo install --example gcs-rsync gcs-rsync
 ### Mirror local folder to gcs
 
 ```bash
-docker run --rm -it -v ${GOOGLE_APPLICATION_CREDENTIALS}:/creds.json:ro -v <YourFolderToUpload>:/source:ro superbeeeeeee/gcs-rsync -r -m /source gs://<YourBucket>/<YourPrefix>
+docker run --rm -it -v ${GOOGLE_APPLICATION_CREDENTIALS}:/creds.json:ro -v <YourFolderToUpload>:/source:ro superbeeeeeee/gcs-rsync -r -m /source gs://<YourBucket>/<YourFolderToUpload>/
 ```
 
 ### Mirror gcs to folder
 
 ```bash
-docker run --rm -it -v ${GOOGLE_APPLICATION_CREDENTIALS}:/creds.json:ro -v <YourFolderToDownloadTo>:/dest superbeeeeeee/gcs-rsync -r -m gs://<YourBucket>/<YourPrefix> /dest
+docker run --rm -it -v ${GOOGLE_APPLICATION_CREDENTIALS}:/creds.json:ro -v <YourFolderToDownloadTo>:/dest superbeeeeeee/gcs-rsync -r -m gs://<YourBucket>/<YourFolderToUpload>/ /dest
 ```
 
 ### Include or Exclude files using glob pattern

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ docker run --rm -it -v ${GOOGLE_APPLICATION_CREDENTIALS}:/creds.json:ro -v <Your
 An example where any json or toml are included recursively except any test.json or test.toml recursively
 ```bash
 docker run --rm -it -v ${GOOGLE_APPLICATION_CREDENTIALS}:/creds.json:ro -v <YourFolderToDownloadTo>:/dest superbeeeeeee/gcs-rsync -r -m -i **/*.json -i **/*.toml -x **/test.json -x **/test.toml
- gs://<YourBucket>/<YourPrefix> /dest
+ gs://<YourBucket>/YourFolderToUpload>/ /dest
 ```
 
 #### Library

--- a/examples/gcs-rsync.rs
+++ b/examples/gcs-rsync.rs
@@ -39,10 +39,13 @@ struct Opt {
     excludes: Vec<String>,
 
     /// Source path: can be either gs (gs://bucket/path/to/object) or fs source
+    /// To synchronize only a prefix: gs://bucket/path/to/your/prefix
+    /// To synchronize a full folder: gs://bucket/path/to/your/folder/ with the trailing slash in the end 
     #[structopt()]
     source: String,
 
     /// Destination path: can be either gs (gs://bucket/path/to/object) or fs source
+    /// To synchronize a full folder: gs://bucket/path/to/your/folder/ with the trailing slash in the end 
     #[structopt()]
     dest: String,
 }

--- a/examples/gcs-rsync.rs
+++ b/examples/gcs-rsync.rs
@@ -40,12 +40,12 @@ struct Opt {
 
     /// Source path: can be either gs (gs://bucket/path/to/object) or fs source
     /// To synchronize only a prefix: gs://bucket/path/to/your/prefix
-    /// To synchronize a full folder: gs://bucket/path/to/your/folder/ with the trailing slash in the end 
+    /// To synchronize a full folder: gs://bucket/path/to/your/folder/ with the trailing slash in the end
     #[structopt()]
     source: String,
 
     /// Destination path: can be either gs (gs://bucket/path/to/object) or fs source
-    /// To synchronize a full folder: gs://bucket/path/to/your/folder/ with the trailing slash in the end 
+    /// To synchronize a full folder: gs://bucket/path/to/your/folder/ with the trailing slash in the end
     #[structopt()]
     dest: String,
 }

--- a/src/gcp/sync/mod.rs
+++ b/src/gcp/sync/mod.rs
@@ -410,10 +410,9 @@ impl std::fmt::Debug for RelativePath {
 }
 
 impl RelativePath {
-    /// Invariant: a name should not start with a slash
     pub fn new(path: &str) -> RSyncResult<Self> {
-        let path = path.strip_prefix('/').unwrap_or(path).to_owned();
-        if path.is_empty() {
+        let path = path.replace('\\', "/").to_owned();
+        if path.is_empty() || path == "/" {
             Err(RSyncError::EmptyRelativePathError)
         } else {
             Ok(Self { path })
@@ -515,7 +514,7 @@ mod tests {
         );
         assert!(is_empty_err(RelativePath::new("/").unwrap_err()));
         assert_eq!(
-            "hello/world",
+            "/hello/world",
             RelativePath::new("/hello/world").unwrap().path
         );
         assert_eq!(

--- a/tests/config/gcs.rs
+++ b/tests/config/gcs.rs
@@ -1,10 +1,8 @@
-use std::path::PathBuf;
-
 use gcs_rsync::{oauth2::token::ServiceAccountCredentials, storage::Object};
 
 pub struct GcsTestConfig {
     bucket: String,
-    prefix: PathBuf,
+    prefix: String,
     list_prefix: String,
     token: ServiceAccountCredentials,
 }
@@ -12,22 +10,19 @@ pub struct GcsTestConfig {
 #[allow(dead_code)] //remove this when this issue will be fixed: https://github.com/rust-lang/rust/issues/46379
 impl GcsTestConfig {
     pub async fn from_env() -> Self {
-        fn to_path_buf(path: &str) -> PathBuf {
+        fn to_path(path: &str) -> String {
             let path = path.strip_prefix('/').unwrap_or(path);
-            let path = if path.ends_with('/') {
+            if path.ends_with('/') {
                 path.to_owned()
             } else {
                 format!("{}/", path)
-            };
-
-            PathBuf::from(path)
+            }
         }
 
         let prefix = {
-            let mut prefix = to_path_buf(env!("TEST_PREFIX"));
+            let prefix = to_path(env!("TEST_PREFIX"));
             let uuid = uuid::Uuid::new_v4().hyphenated().to_string();
-            prefix.push(uuid);
-            prefix
+            format!("{prefix}{uuid}")
         };
         let path = env!("TEST_SERVICE_ACCOUNT");
         let sac = ServiceAccountCredentials::from_file(path)
@@ -37,17 +32,17 @@ impl GcsTestConfig {
         Self {
             bucket: env!("TEST_BUCKET").to_owned(),
             prefix: prefix.to_owned(),
-            list_prefix: prefix.to_string_lossy().to_string(),
+            list_prefix: prefix.to_owned(),
             token: sac,
         }
     }
 
     pub fn object(&self, name: &str) -> Object {
-        let mut path = self.prefix.clone();
-        path.push(name);
+        let path = self.prefix.clone();
+        let name = format!("{path}/{name}");
         Object {
             bucket: self.bucket.to_owned(),
-            name: path.to_string_lossy().to_string(),
+            name,
         }
     }
 
@@ -59,8 +54,14 @@ impl GcsTestConfig {
         self.bucket.to_owned()
     }
 
-    pub fn prefix(&self) -> PathBuf {
-        self.prefix.to_owned()
+    pub fn prefix_as_folder(&self) -> String {
+        let prefix = self.prefix.as_str();
+        format!("{prefix}/")
+    }
+
+    pub fn prefix(&self) -> String {
+        let prefix = self.prefix.as_str();
+        prefix.strip_suffix('/').unwrap_or(prefix).to_owned()
     }
 
     pub fn token(self) -> ServiceAccountCredentials {

--- a/tests/no_auth_public_download_tests.rs
+++ b/tests/no_auth_public_download_tests.rs
@@ -7,7 +7,7 @@ use gcs_rsync::sync::{RSyncStatus, RelativePath};
 #[tokio::test]
 async fn test_public_download_without_any_auth() {
     let fs_test_config = FsTestConfig::new();
-    let source = gcs_rsync::sync::ReaderWriter::gcs_no_auth("gcs-rsync-dev-public", "");
+    let source = gcs_rsync::sync::ReaderWriter::gcs_no_auth("gcs-rsync-dev-public", "hello");
     let dest = gcs_rsync::sync::ReaderWriter::fs(&fs_test_config.base_path());
     let rsync = gcs_rsync::sync::RSync::new(source, dest);
     let sync_results = rsync

--- a/tests/objects_integration_test.rs
+++ b/tests/objects_integration_test.rs
@@ -22,7 +22,7 @@ async fn test_test_config() {
     );
     let name = t.object("object_name").name;
     assert!(
-        name.ends_with("/object_name") || name.ends_with("\\object_name"),
+        name.ends_with("/object_name"),
         "object name should end with /object_name"
     );
 


### PR DESCRIPTION
- [x] add prefix support
- [x] backlash are converted to slash to avoid synchronisation mess on remote gcs which supports slash as folder separator 
  - 2 way merge with windows and linux os.

gcs-rsync will not add the extra slash in the prefix anymore to fully support prefix and partial sync.

Previously, gcs-rsync assumed that prefix was always a folder (by adding an extra slash at the end of prefix search) while with this new feature, the folder is inferred (by detecting the current folder with last slash) to be stripped from the relative path.

- Synchronise _/hello/world_ prefix with to _/dest_ prefix files like:
  - __Before this feature__
    - /hello/world2.txt > does not match /hello/world/ (with the extra slash defaulted by gcs-rsync)
    - /hello/world/test.txt > /dest/test.txt
    - /hello/text.txt > no synced since it does not match the source prefix.
  - __After this feature__
    - /hello/world2.txt > __/dest/world2.txt__ (now synchronized)
    - /hello/world/test.txt > /dest/<b>world/</b>test.txt (_world_ subfolder is added)
    - /hello/text.txt > no synced since it does not match the source prefix.
  
Backward compatibility: simply add a slash at the end of the prefix and the behavior will remains same as before:
  - Now, synchronising with _/hello/world<b>/</b>_ prefix to _/dest_ prefix files is like before:
    - /hello/world2.txt > does not match /hello/world/ (with the extra slash defaulted by gcs-rsync)
    - /hello/world/test.txt > /dest/test.txt
    - /hello/text.txt > no synced since it does not match the source prefix.
