### PR TITLE
Properly convert to microseconds calculation when deserializing token

### DIFF
--- a/src/gcp/oauth2/token.rs
+++ b/src/gcp/oauth2/token.rs
@@ -26,12 +26,14 @@ pub struct Token {
 
 const ONE_SECOND_TO_MICROSECONDS: i64 = 1_000_000;
 
-fn from_expires_in<'de, D>(deserializer: D) -> std::result::Result<DateTime<Utc>, D::Error>
+pub(super) fn from_expires_in<'de, D>(
+    deserializer: D,
+) -> std::result::Result<DateTime<Utc>, D::Error>
 where
     D: Deserializer<'de>,
 {
     let expires_in: i64 = Deserialize::deserialize(deserializer)?;
-    Ok(Utc::now() + chrono::Duration::microseconds(expires_in * 1000_1000))
+    Ok(Utc::now() + chrono::Duration::microseconds(expires_in * ONE_SECOND_TO_MICROSECONDS))
 }
 
 impl Display for Token {


### PR DESCRIPTION
We started noticing 401s in an application that uses this crate, and when digging into the code I noticed the logic changes for expiry calculation in https://github.com/cboudereau/gcs-rsync/commit/5e3df56c7a25f49f5f6e14dd40f9953c6eb59441