### PR TITLE
feat: configure host with STORAGE_EMULATOR_HOST env var

### DIFF
--- a/src/gcp/storage/client.rs
+++ b/src/gcp/storage/client.rs
@@ -141,7 +141,9 @@ impl StorageClient {
 
     pub async fn delete(&self, url: &str) -> StorageResult<()> {
         let url = self.resolve_url(url);
-        let request = self.with_auth(self.client.client.delete(url.as_str())).await?;
+        let request = self
+            .with_auth(self.client.client.delete(url.as_str()))
+            .await?;
         let response = request
             .send()
             .await
@@ -157,7 +159,9 @@ impl StorageClient {
         bytes::Bytes: From<S::Ok>,
     {
         let url = self.resolve_url(url);
-        let request = self.with_auth(self.client.client.post(url.as_str())).await?;
+        let request = self
+            .with_auth(self.client.client.post(url.as_str()))
+            .await?;
         let response = request
             .body(reqwest::Body::wrap_stream(body))
             .send()
@@ -273,11 +277,12 @@ impl StorageClient {
             .send()
             .await
             .map_err(super::Error::GcsHttpJsonRequestError)?;
-        let r: super::super::DeserializedResponse<R> = Self::success_response(url.as_str(), response)
-            .await?
-            .json()
-            .await
-            .map_err(super::Error::GcsHttpJsonResponseError)?;
+        let r: super::super::DeserializedResponse<R> =
+            Self::success_response(url.as_str(), response)
+                .await?
+                .json()
+                .await
+                .map_err(super::Error::GcsHttpJsonResponseError)?;
         r.into_result()
             .map_err(|err| super::Error::gcs_unexpected_json::<R>(url.as_str(), err))
     }

--- a/src/gcp/storage/client.rs
+++ b/src/gcp/storage/client.rs
@@ -65,6 +65,7 @@ impl TokenStateHolder {
 pub(super) struct StorageClient {
     client: Client,
     token_state_holder: Option<TokenStateHolder>,
+    host: String,
 }
 
 const MT_SEPARATOR: &[u8] = b"--gcs-storage\n";
@@ -73,24 +74,32 @@ const MT_CONTENT_TYPE: &[u8] = b"Content-Type: application/octet-stream";
 const MT_METADATA_TYPE: &[u8] = b"Content-Type: application/json; charset=utf-8\n\n";
 
 impl StorageClient {
+    fn get_host() -> String {
+        let host = std::env::var("STORAGE_EMULATOR_HOST")
+            .unwrap_or("https://storage.googleapis.com".to_owned());
+        host.strip_suffix("/").unwrap_or(&host).to_owned()
+    }
+
     pub async fn new(token_generator: Box<dyn TokenGenerator>) -> StorageResult<Self> {
         let client = Client::default();
         let token_state_holder =
             Some(TokenStateHolder::new(client.clone(), token_generator).await?);
-
+        let host = Self::get_host();
         Ok(Self {
             client,
             token_state_holder,
+            host,
         })
     }
 
     pub fn no_auth() -> Self {
         let client = Client::default();
         let token_state_holder = None;
-
+        let host = Self::get_host();
         Self {
             client,
             token_state_holder,
+            host,
         }
     }
 
@@ -125,13 +134,19 @@ impl StorageClient {
         }
     }
 
+    fn resolve_url(&self, url: &str) -> String {
+        let host = self.host.to_owned();
+        format!("{host}/{url}")
+    }
+
     pub async fn delete(&self, url: &str) -> StorageResult<()> {
-        let request = self.with_auth(self.client.client.delete(url)).await?;
+        let url = self.resolve_url(url);
+        let request = self.with_auth(self.client.client.delete(url.as_str())).await?;
         let response = request
             .send()
             .await
             .map_err(super::Error::GcsHttpDeleteError)?;
-        Self::success_response(url, response).await?;
+        Self::success_response(url.as_str(), response).await?;
         Ok(())
     }
 
@@ -141,14 +156,15 @@ impl StorageClient {
         S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
         bytes::Bytes: From<S::Ok>,
     {
-        let request = self.with_auth(self.client.client.post(url)).await?;
+        let url = self.resolve_url(url);
+        let request = self.with_auth(self.client.client.post(url.as_str())).await?;
         let response = request
             .body(reqwest::Body::wrap_stream(body))
             .send()
             .await
             .map_err(super::Error::GcsHttpPostError)?;
 
-        Self::success_response(url, response).await?;
+        Self::success_response(url.as_str(), response).await?;
         Ok(())
     }
 
@@ -176,6 +192,8 @@ impl StorageClient {
         S: TryStream<Ok = bytes::Bytes> + Send + Sync + 'static,
         S::Error: Into<Box<dyn std::error::Error + Send + Sync>> + Send + Sync,
     {
+        let url = self.resolve_url(url);
+
         let json = serde_json::ser::to_vec(metadata).map_err(Error::gcs_invalid_metadata::<M>)?;
 
         let part_len = 2 * MT_SEPARATOR.len()
@@ -204,7 +222,7 @@ impl StorageClient {
         };
 
         // let total_len = part_len as u64 + size + MT_END_SEPARATOR.len() as u64;
-        let request = self.client.client.post(url);
+        let request = self.client.client.post(url.as_str());
         let request = self.with_auth(request).await?;
         let response = request
             .header("Content-Type", "multipart/related; boundary=gcs-storage")
@@ -214,7 +232,7 @@ impl StorageClient {
             .await
             .map_err(super::Error::GcsHttpPostMultipartError)?;
 
-        Self::success_response(url, response).await?;
+        Self::success_response(url.as_str(), response).await?;
         Ok(())
     }
 
@@ -226,14 +244,16 @@ impl StorageClient {
     where
         Q: Serialize,
     {
-        let request = self.with_auth(self.client.client.get(url)).await?;
+        let url = self.resolve_url(url);
+
+        let request = self.with_auth(self.client.client.get(url.as_str())).await?;
         let response = request
             .query(query)
             .send()
             .await
             .map_err(super::Error::GcsHttpGetAsStreamError)?;
 
-        Ok(Self::success_response(url, response)
+        Ok(Self::success_response(url.as_str(), response)
             .await?
             .bytes_stream()
             .map_err(super::Error::GcsHttpBytesStreamError))
@@ -244,19 +264,21 @@ impl StorageClient {
         R: DeserializeOwned,
         Q: serde::Serialize,
     {
+        let url = self.resolve_url(url);
+
         let request = self
-            .with_auth(self.client.client.get(url).query(query))
+            .with_auth(self.client.client.get(url.as_str()).query(query))
             .await?;
         let response = request
             .send()
             .await
             .map_err(super::Error::GcsHttpJsonRequestError)?;
-        let r: super::super::DeserializedResponse<R> = Self::success_response(url, response)
+        let r: super::super::DeserializedResponse<R> = Self::success_response(url.as_str(), response)
             .await?
             .json()
             .await
             .map_err(super::Error::GcsHttpJsonResponseError)?;
         r.into_result()
-            .map_err(|err| super::Error::gcs_unexpected_json::<R>(url, err))
+            .map_err(|err| super::Error::gcs_unexpected_json::<R>(url.as_str(), err))
     }
 }

--- a/src/gcp/storage/resources/object.rs
+++ b/src/gcp/storage/resources/object.rs
@@ -87,8 +87,9 @@ impl FromStr for Object {
 
 type GsUrl = String;
 
-const BASE_URL: &str = "https://storage.googleapis.com/storage/v1";
-const UPLOAD_BASE_URL: &str = "https://storage.googleapis.com/upload/storage/v1";
+// https://storage.googleapis.com/
+const BASE_URL: &str = "storage/v1";
+const UPLOAD_BASE_URL: &str = "upload/storage/v1";
 
 fn percent_encode(input: &str) -> String {
     percent_encoding::utf8_percent_encode(input, percent_encoding::NON_ALPHANUMERIC).to_string()
@@ -299,7 +300,7 @@ mod tests {
     fn test_object_url() {
         let o = Object::new("hello/hello", "world/world").unwrap();
         assert_eq!(
-            "https://storage.googleapis.com/storage/v1/b/hello%2Fhello/o/world%2Fworld",
+            "storage/v1/b/hello%2Fhello/o/world%2Fworld",
             o.url()
         );
     }
@@ -308,7 +309,7 @@ mod tests {
     fn test_object_upload_url() {
         let o = Object::new("hello/hello", "world/world").unwrap();
         assert_eq!(
-            "https://storage.googleapis.com/upload/storage/v1/b/hello%2Fhello/o?uploadType=media&name=world%2Fworld",
+            "upload/storage/v1/b/hello%2Fhello/o?uploadType=media&name=world%2Fworld",
             o.upload_url("media")
         );
     }
@@ -317,7 +318,7 @@ mod tests {
     fn test_bucket_url() {
         let b = Bucket::new("hello/hello");
         assert_eq!(
-            "https://storage.googleapis.com/storage/v1/b/hello%2Fhello/o",
+            "storage/v1/b/hello%2Fhello/o",
             b.url()
         );
     }

--- a/src/gcp/storage/resources/object.rs
+++ b/src/gcp/storage/resources/object.rs
@@ -299,10 +299,7 @@ mod tests {
     #[test]
     fn test_object_url() {
         let o = Object::new("hello/hello", "world/world").unwrap();
-        assert_eq!(
-            "storage/v1/b/hello%2Fhello/o/world%2Fworld",
-            o.url()
-        );
+        assert_eq!("storage/v1/b/hello%2Fhello/o/world%2Fworld", o.url());
     }
 
     #[test]
@@ -317,10 +314,7 @@ mod tests {
     #[test]
     fn test_bucket_url() {
         let b = Bucket::new("hello/hello");
-        assert_eq!(
-            "storage/v1/b/hello%2Fhello/o",
-            b.url()
-        );
+        assert_eq!("storage/v1/b/hello%2Fhello/o", b.url());
     }
 
     #[test]

--- a/tests/sync_mirror_integration_tests.rs
+++ b/tests/sync_mirror_integration_tests.rs
@@ -245,11 +245,11 @@ async fn test_fs_to_gcs_sync_and_mirror_base(set_fs_mtime: bool) {
     let fs_source = Source::fs(src_t.base_path().as_path());
     let fs_source_replica = Source::fs(src_t.base_path().as_path());
 
-    let fs_replica_t = FsTestConfig::new();
-    let fs_dest_replica = Source::fs(fs_replica_t.base_path().as_path());
+    let fs_dest_replica_t = FsTestConfig::new();
+    let fs_dest_replica = Source::fs(fs_dest_replica_t.base_path().as_path());
 
-    let fs_replica_t2 = FsTestConfig::new();
-    let fs_dest_replica2 = Source::fs(fs_replica_t2.base_path().as_path());
+    let fs_dest_replica_t2 = FsTestConfig::new();
+    let fs_dest_replica2 = Source::fs(fs_dest_replica_t2.base_path().as_path());
 
     let rsync_fs_to_gcs = RSync::new(fs_source, gcs_dest).with_restore_fs_mtime(set_fs_mtime);
     let rsync_gcs_to_gcs_replica =


### PR DESCRIPTION
Closes #45 

Add an env var `STORAGE_EMULATOR_HOST` (see [golang reference](https://github.com/googleapis/google-cloud-go/blob/a9dec0763f85f083cc1da451249caae7ad97d904/storage/TESTING.md?plain=1#L31)) to support emulators

- [x] add host to StorageClient
- [x] get host using env var `STORAGE_EMULATOR_HOST`
- [x] make object url relative 
- [x] update StorageClient to combine host + relative url.