### PR TITLE
feat: check that the source is valid when mirroring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcs-rsync"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2021"
 description = "rsync support for gcs with higher perf than gsutil rsync"
 license = "MIT"

--- a/examples/bucket_to_folder_mirror.rs
+++ b/examples/bucket_to_folder_mirror.rs
@@ -29,7 +29,7 @@ async fn main() -> RSyncResult<()> {
 
     rsync
         .mirror()
-        .await
+        .await?
         .try_buffer_unordered(12)
         .try_filter(|x| match *x {
             RMirrorStatus::NotDeleted(_) => futures::future::ready(false),

--- a/examples/gcs-rsync.rs
+++ b/examples/gcs-rsync.rs
@@ -152,7 +152,7 @@ async fn main() -> RSyncResult<()> {
         println!("mirroring {} > {}", &opt.source, &opt.dest);
         rsync
             .mirror()
-            .await
+            .await?
             .try_buffer_unordered(num_cpus)
             .for_each(|x| {
                 println!("{:?}", x);

--- a/src/gcp/storage/resources/object.rs
+++ b/src/gcp/storage/resources/object.rs
@@ -150,7 +150,7 @@ impl Bucket {
     }
 
     pub fn url(&self) -> String {
-        format!("{}/b/{}/o", BASE_URL, percent_encode(&self.name))
+        format!("{}/b/{}", BASE_URL, percent_encode(&self.name))
     }
 }
 
@@ -314,7 +314,7 @@ mod tests {
     #[test]
     fn test_bucket_url() {
         let b = Bucket::new("hello/hello");
-        assert_eq!("storage/v1/b/hello%2Fhello/o", b.url());
+        assert_eq!("storage/v1/b/hello%2Fhello", b.url());
     }
 
     #[test]

--- a/src/gcp/sync/fs.rs
+++ b/src/gcp/sync/fs.rs
@@ -49,6 +49,7 @@ impl FsClient {
         let path_exists = tokio::fs::try_exists(path).await.map_err(|err| {
             RSyncError::fs_io_error("error while checking file system path", path, err)
         })?;
+
         if path_exists {
             Ok(())
         } else {

--- a/src/gcp/sync/fs.rs
+++ b/src/gcp/sync/fs.rs
@@ -44,6 +44,21 @@ pub(super) struct FsClient {
 type Size = u64;
 
 impl FsClient {
+    pub(super) async fn is_valid(&self) -> RSyncResult<()> {
+        let path = self.prefix.base_path.as_path();
+        let path_exists = tokio::fs::try_exists(path).await.map_err(|err| {
+            RSyncError::fs_io_error("error while checking file system path", path, err)
+        })?;
+        if path_exists {
+            Ok(())
+        } else {
+            Err(RSyncError::InvalidRsyncSource(format!(
+                "path {:?} does not exist",
+                path
+            )))
+        }
+    }
+
     pub(super) fn new(base_path: &Path) -> Self {
         let prefix = FsPrefix::new(base_path);
         Self { prefix }

--- a/src/gcp/sync/gcs.rs
+++ b/src/gcp/sync/gcs.rs
@@ -94,6 +94,13 @@ impl GcsClient {
         }
     }
 
+    pub(super) async fn is_valid(&self) -> RSyncResult<()> {
+        self.client
+            .is_valid(&self.object_prefix.bucket, &self.object_prefix.prefix)
+            .await
+            .map_err(RSyncError::StorageError)
+    }
+
     pub(super) async fn list(&self) -> impl Stream<Item = RSyncResult<RelativePath>> + '_ {
         self.client
             .list(

--- a/tests/config/fs.rs
+++ b/tests/config/fs.rs
@@ -44,6 +44,6 @@ impl FsTestConfig {
 impl Drop for FsTestConfig {
     fn drop(&mut self) {
         let path = self.base_path.as_path();
-        std::fs::remove_dir_all(path).unwrap();
+        std::fs::remove_dir_all(path).unwrap_or(());
     }
 }

--- a/tests/no_auth_public_download_tests.rs
+++ b/tests/no_auth_public_download_tests.rs
@@ -11,14 +11,15 @@ async fn test_public_bucket_mirror_when_fs_source_does_not_exist() {
     let dest = gcs_rsync::sync::ReaderWriter::fs(&fs_test_config.base_path());
 
     let rsync = gcs_rsync::sync::RSync::new(source, dest);
-    let r = rsync.mirror().await;
-
-    let r2 = r.unwrap();
 
     let mut oks = Vec::new();
-
     let mut fs_io_errors = Vec::new();
-    r2.try_buffer_unordered(config::default::CONCURRENCY_LEVEL)
+
+    rsync
+        .mirror()
+        .await
+        .unwrap()
+        .try_buffer_unordered(config::default::CONCURRENCY_LEVEL)
         .for_each(|r| {
             match r {
                 Ok(x) => oks.push(x),

--- a/tests/no_auth_public_download_tests.rs
+++ b/tests/no_auth_public_download_tests.rs
@@ -1,29 +1,45 @@
 mod config;
 
 use config::fs::FsTestConfig;
-use futures::TryStreamExt;
-use gcs_rsync::sync::{RSyncStatus, RelativePath};
+use futures::{StreamExt, TryStreamExt};
+use gcs_rsync::sync::{RMirrorStatus, RSyncError, RSyncStatus, RelativePath};
 
 #[tokio::test]
-async fn test_public_download_without_any_auth() {
+async fn test_public_bucket_mirror_when_fs_source_does_not_exist() {
     let fs_test_config = FsTestConfig::new();
     let source = gcs_rsync::sync::ReaderWriter::gcs_no_auth("gcs-rsync-dev-public", "hello");
     let dest = gcs_rsync::sync::ReaderWriter::fs(&fs_test_config.base_path());
+
     let rsync = gcs_rsync::sync::RSync::new(source, dest);
-    let sync_results = rsync
-        .sync()
-        .await
-        .try_buffer_unordered(config::default::CONCURRENCY_LEVEL)
-        .try_collect::<Vec<_>>()
-        .await
-        .unwrap();
+    let r = rsync.mirror().await;
+
+    let r2 = r.unwrap();
+
+    let mut oks = Vec::new();
+
+    let mut fs_io_errors = Vec::new();
+    r2.try_buffer_unordered(config::default::CONCURRENCY_LEVEL)
+        .for_each(|r| {
+            match r {
+                Ok(x) => oks.push(x),
+                Err(x) => {
+                    if let RSyncError::FsIoError { .. } = x {
+                        fs_io_errors.push(x)
+                    };
+                }
+            }
+            futures::future::ready(())
+        })
+        .await;
 
     assert_eq!(
-        vec![RSyncStatus::Created(
+        vec![RMirrorStatus::Synced(RSyncStatus::Created(
             RelativePath::new("hello.txt").unwrap()
-        )],
-        sync_results
+        ))],
+        oks
     );
+
+    assert_eq!(1, fs_io_errors.len());
 
     let content = fs_test_config.read_to_string("hello.txt").await;
 

--- a/tests/sync_mirror_integration_tests.rs
+++ b/tests/sync_mirror_integration_tests.rs
@@ -68,6 +68,7 @@ async fn mirror(fs_client: &RSync) -> Vec<RMirrorStatus> {
     let mut actual = fs_client
         .mirror()
         .await
+        .unwrap()
         .try_buffer_unordered(config::default::CONCURRENCY_LEVEL)
         .try_collect::<Vec<_>>()
         .await
@@ -569,5 +570,25 @@ async fn test_mirror_include_and_exclude_rsync_conf() {
             not_deleted("hello/world/test.txt"),
         ],
         actual
+    );
+}
+
+#[tokio::test]
+async fn test_mirror_when_gcs_dest_doest_not_exist() {
+    let fs_test_config = FsTestConfig::new();
+    let test_file_name = "test.txt";
+    let test_file_content = "hello";
+    let test_file_path = fs_test_config.file_path(test_file_name);
+
+    write_to_file(&test_file_path, test_file_content).await;
+
+    let source = gcs_rsync::sync::ReaderWriter::gcs_no_auth("this-bucket-does-not-exist", "hello");
+    let dest = gcs_rsync::sync::ReaderWriter::fs(&fs_test_config.base_path());
+
+    let rsync = gcs_rsync::sync::RSync::new(source, dest);
+    assert!(rsync.mirror().await.is_err());
+    assert_eq!(
+        test_file_content,
+        fs_test_config.read_to_string(test_file_name).await
     );
 }

--- a/tests/sync_mirror_integration_tests.rs
+++ b/tests/sync_mirror_integration_tests.rs
@@ -592,3 +592,14 @@ async fn test_mirror_when_gcs_dest_doest_not_exist() {
         fs_test_config.read_to_string(test_file_name).await
     );
 }
+
+#[tokio::test]
+async fn test_mirror_when_fs_dest_doest_not_exist() {
+    let fs_test_config = FsTestConfig::new();
+
+    let source = gcs_rsync::sync::ReaderWriter::fs(&fs_test_config.base_path());
+    let dest = gcs_rsync::sync::ReaderWriter::gcs_no_auth("this-bucket-does-not-exist", "hello");
+
+    let rsync = gcs_rsync::sync::RSync::new(source, dest);
+    assert!(rsync.mirror().await.is_err());
+}


### PR DESCRIPTION
Closes #48 

Now, the mirror checks first that the source is valid before doing sync + extra file deletion.

Note: The [gcs json api does not provide the bucket api for public bucket](https://cloud.google.com/storage/docs/json_api/v1/buckets/get). It works only with request using auth. Only the listing bucket works correctly. To check that the destination is_valid, for gcs, calling the list but asking for 1 result does the job.

⚠️ Lib breaking changes: the mirror returns a Result instead of the Stream directly to ensure that the rsync parameters are valid first. The app and the docker image are not impacted and work like before though. Only the library mirror function has been impacted.